### PR TITLE
Correct test error message

### DIFF
--- a/test/flow-control-test.js
+++ b/test/flow-control-test.js
@@ -72,7 +72,7 @@ describe('flow-control', () => {
       expect(switchAge(15)).toEqual("You are a teenager")
     })
 
-    it('should return "You are not a teenager" if age not between 13-19', () => {
+    it('should return "You have an age" if age not between 13-19', () => {
       expect(switchAge(75)).toEqual("You have an age")
       expect(switchAge(7)).toEqual("You have an age")
     })


### PR DESCRIPTION
Updated the string for the error message on switchAge test, which was reporting that it needed a "You are not a teenager" string to pass.